### PR TITLE
draft: new tvm endpoint to get credentials for other namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A set of Adobe I/O TVM actions are deployed behind the Adobe I/O Gateway at `htt
 
 - cURL
   - requirements: valid Adobe I/O Runtime credentials, `namespace` and `auth`
-  - endpoints: `azure/blob/{namespace}`, `azure/cosmos/{namespace}`, `aws/s3/{namespace}`, `azure/presign/{namespace}`
+  - endpoints: `azure/blob/{namespace}`, `azure/cosmos/{namespace}`, `aws/s3/{namespace}`, `azure/presign/{namespace}`, `admin/{namespace}/all/{requestedNamespace}`
 
 ```bash
 curl "https://firefly-tvm.adobe.io/azure/blob/{namespace}" \

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ This might be useful for you if:
   # TVM credentials options
   EXPIRATION_DURATION=<token expiration in seconds>
   APPROVED_LIST=<comma separated list of namespaces>
+  ADMIN_LIST=<comma separated list of namespaces>
 
   # AWS S3 credentials
   AWS_ACCESS_KEY_ID=<key id of IAM user created in AWS>
@@ -85,6 +86,9 @@ This might be useful for you if:
   hence who can deploy files to your S3 Bucket.
   - **[ ⚠️ NOT RECOMMENDED ⚠️]** Use `APPROVED_LIST=*` to allow access to
     **every** OpenWhisk namespace in the same domain.
+
+- Use the `ADMIN_LIST` variable to control which namespaces can access the TVM admin
+  endpoints and hence who can retrieve credentials for any namespace in the same domain.
 
 ### Setup Azure Blob
 

--- a/actions/admin-all/index.js
+++ b/actions/admin-all/index.js
@@ -1,0 +1,23 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+const { AdminTvm } = require('../../lib/impl/AdminTvm')
+const adminTvm = new AdminTvm()
+
+/**
+ * @param {object} params the input params
+ * @returns {Promise<object>} tvm response
+ */
+async function main (params) {
+  return adminTvm.processRequest(params)
+}
+
+exports.main = main

--- a/actions/utils.js
+++ b/actions/utils.js
@@ -1,0 +1,21 @@
+/**
+ * PromiseAll replacement for an object with key-values of promises. Returns promise 
+ * data with the appropriate key name. 
+ * @param {Object} obj 
+ * @returns {Object}
+ */
+function objectPromise(obj) {
+    return Promise.all(
+        Object
+            .keys(obj)
+            .map(key => Promise.resolve(obj[key]).then(val => ({ key: key, val: val })))
+    ).then(items => {
+        let result = {};
+        items.forEach(item => result[item.key] = item.val);
+        return result;
+    });
+}
+
+module.exports = {
+    objectPromise
+}

--- a/lib/Tvm.js
+++ b/lib/Tvm.js
@@ -296,6 +296,11 @@ class Tvm {
 
       logger.info(`request is authorized - request Id - ${requestId}`)
 
+      // hack - if creds were requested for a specific namespace, accommodate
+      if (params.hasOwnProperty('requestedOwNamespace')) {
+        params.owNamespace = requestedOwNamespace
+      }
+
       // 3. generate credentials
       const credentials = await this._generateCredentials(params)
 
@@ -320,6 +325,18 @@ class Tvm {
         }
       }
     }
+  }
+
+  /**
+   * Process OpenWhisk admin web request, generates credentials upon OpenWhisk auth validation and responds back with the credentials
+   *
+   * @param {object} params OpenWhisk web request params
+   * @returns {Promise<object>} { body: <object>, statusCode: <number> }, if returns an error there is a body.error
+   * @memberof Tvm
+   */
+  async processAdminRequest (params) {
+    this._addToValidationSchema('owRequestedNamespace')
+    return this.processRequest(params)
   }
 }
 

--- a/lib/impl/AdminTvm.js
+++ b/lib/impl/AdminTvm.js
@@ -1,0 +1,89 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const { Tvm } = require('../Tvm')
+
+const { AwsS3Tvm } = require('../impl/AwsS3Tvm')    
+let awsS3tvm = new AwsS3Tvm()
+
+const { AzureBlobTvm } = require('../impl/AzureBlobTvm')
+let azureBlobTvm = new AzureBlobTvm()
+
+const { AzureCosmosTvm } = require('../impl/AzureCosmosTvm')
+let azureCosmosTvm = new AzureCosmosTvm()
+
+const aws = require('aws-sdk')
+const { objectPromise } = require('../../actions/utils')
+
+/**
+ * @class AdminTvm
+ * @classdesc Tvm implementation for Admin
+ * @augments {Tvm}
+ */
+class AdminTvm extends Tvm {
+  /**
+   * @memberof AdminTvm
+   * @override
+   */
+  constructor () {
+    super()
+    this._addToValidationSchema('requestedOwNamespace')
+    this._addToValidationSchema('s3Bucket')
+    this._addToValidationSchema('awsAccessKeyId')
+    this._addToValidationSchema('awsSecretAccessKey')
+    this._addToValidationSchema('azureStorageAccount')
+    this._addToValidationSchema('azureStorageAccessKey')
+    this._addToValidationSchema('azureCosmosAccount')
+    this._addToValidationSchema('azureCosmosMasterKey')
+    this._addToValidationSchema('azureCosmosDatabaseId')
+    this._addToValidationSchema('azureCosmosContainerId')
+  }
+
+  /**
+   * @memberof AdminTvm
+   * @override
+   * @private
+   */
+  async _generateCredentials (params) {
+
+    let baseParams = {
+        expirationDuration: params.expirationDuration,
+        approvedList: params.approvedList, 
+        owApihost: params.owApihost, 
+        disableAdobeIOApiGwTokenValidation: params.disableAdobeIOApiGwTokenValidation,
+        imsEnv: params.imsEnv,
+        owNamespace: params.owNamespace,
+        owAuth: params.owAuth,
+        requestedOwNamespace: params.requestedOwNamespace
+    }
+
+    return objectPromise({
+        s3: awsS3tvm.processAdminRequest({ ...baseParams, 
+            s3Bucket: params.s3Bucket, 
+            awsAccessKeyId: params.awsAccessKeyId, 
+            awsSecretAccessKey: params.awsSecretAccessKey
+        }),
+        azureBlob: azureBlobTvm.processAdminRequest({ ...baseParams,
+            azureStorageAccount: params.azureStorageAccount, 
+            azureStorageAccessKey: params.azureStorageAccessKey
+        }),
+        azureCosmosTvm: azureCosmosTvm.processAdminRequest({ ...baseParams,
+            azureCosmosAccount: params.azureCosmosAccount, 
+            azureCosmosMasterKey: params.azureCosmosMasterKey, 
+            azureCosmosDatabaseId: params.azureCosmosDatabaseId, 
+            azureCosmosContainerId: params.azureCosmosContainerId
+        })
+    })
+  }
+}
+
+module.exports = { AdminTvm }

--- a/manifest.yml
+++ b/manifest.yml
@@ -79,6 +79,27 @@ packages:
         annotations:
           # this is important security wise
           final: true
+      admin-all:
+        function: actions/admin-all/index.js
+        web: yes
+        runtime: 'nodejs:14'
+        inputs:
+          s3Bucket: $S3_BUCKET
+          awsSecretAccessKey: $AWS_SECRET_ACCESS_KEY
+          awsAccessKeyId: $AWS_ACCESS_KEY_ID          
+          azureStorageAccount: $AZURE_STORAGE_ACCOUNT
+          azureStorageAccessKey: $AZURE_STORAGE_ACCESS_KEY
+          azureCosmosMasterKey: $AZURE_COSMOS_MASTER_KEY
+          azureCosmosAccount: $AZURE_COSMOS_ACCOUNT
+          azureCosmosDatabaseId: $AZURE_COSMOS_DATABASE_ID
+          azureCosmosContainerId: $AZURE_COSMOS_CONTAINER_ID
+          expirationDuration: $EXPIRATION_DURATION
+          owApihost: $AIO_RUNTIME_APIHOST
+          approvedList: $ADMIN_LIST
+          imsEnv: $IMS_ENV
+          disableAdobeIOApiGwTokenValidation: $DISABLE_ADOBE_IO_API_GW_TOKEN_VALIDATION
+        annotations:
+          final: true
     apis:
       tvm-azure-blob:
         tvm:
@@ -108,5 +129,11 @@ packages:
         tvm:
           aws/s3/{owNamespace}:
             aws-s3:
+              method: GET
+              response: http
+      tvm-admin-all:
+        tvm:
+          admin/{owNamespace}/all/{requestedOwNamespace}:
+            admin-all:
               method: GET
               response: http


### PR DESCRIPTION
Add a new tvm endpoint that allows a requester from one ow namespace to get credentials for another, based on a whitelist. 

This was one of the shortest paths I could see to achieve this functionality. Still not sure how I feel about performing adobe i/o gw token validation, ow credential validation, and request param validation in `processRequest` n-times over (however many other tvms we add in the future). I toyed with a refactor to break out the responsibilities of that function to make it more modular so we could avoid this, but ended up scrapping it because it would make rewriting the tests a pretty sizable task and also introduced more changes across the board than I was comfortable with (hence increasing risk for breaking other endpoints).

## Description

## Related Issue

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes


- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
